### PR TITLE
Ticket #6927: Slash commands to send url to check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,14 @@ before_install:
 - sudo service elasticsearch restart
 - sleep 15
 - sudo service elasticsearch status
+- git clone https://github.com/meedan/pender.git
+- d=configurator/check/travis/pender/; for f in $(find $d -type f); do cp "$f" "pender/${f/$d/}"; done
+- cd pender
+- bundle install --path=/tmp/bundler
+- bundle exec rake db:migrate
+- bundle exec rails runner 'a = ApiKey.create!; a.access_token = "test"; a.save!'
+- bundle exec rails s -p 3005 >/dev/null &
+- cd -
 - git clone https://github.com/meedan/check-api.git
 - d=configurator/check/travis/check-api/; for f in $(find $d -type f); do cp "$f" "check-api/${f/$d/}"; done
 - cd check-api

--- a/README.md
+++ b/README.md
@@ -21,19 +21,26 @@ The steps below reference the **white** circles on the diagram above.
 * Back to your computer, copy `config.js.example` to `config.js` and define your configurations
 * Copy `aws.json.example` to `aws.json` and add your AWS credentials
 * Install the dependencies with `npm i` and generate a ZIP package with `npm run build`
-* The same `./dist/aws_lambda_functions.zip` file that was generated should be uploaded to three lambda functions **[2]**. The following sections explain how those three functions should be created.
+* The same `./dist/aws_lambda_functions.zip` file that was generated should be uploaded to five lambda functions **[2]**. The following sections explain how those five functions should be created.
 * Create a Lambda function called `check-slack-bot`, whose handler is `index.handler`. It should use subnets `B`, `C` and `D`. **[3]**
 * Add a trigger to this Lambda function, of type "API Gateway". The API should have a single endpoint, that accepts only `POST` requests. Remember to deploy your API once done. **[4]**
 * Create a Lambda function called `check-slack-bot-buttons`, whose handler is `buttons.handler`. It should use subnets `B`, `C` and `D`. **[5]**
 * Add a trigger to this Lambda function, of type "API Gateway". The API should have a single endpoint, that accepts only `POST` requests. By default, the AWS API Gateway only accepts `application/json` requests, but Slack is going to send `application/x-www-form-urlencoded` requests when a message button is clicked. So, add a `Body Mapping Template` to your API `POST` method for the content type `application/x-www-form-urlencoded`. The contents of the template should be `{ "body": "$input.body" }`. Also, under the "Binary Support" section, add `application/x-www-form-urlencoded` as a content type to be considered binary input. Remember to deploy your API once all those things are done. **[6]**
 * Create a Lambda function called `google-image-search`, whose handler is `google-image-search.handler` **[7]**
-* Now on the Slack app side **[8]**, you need to do a few things:
+* Create a Lambda function called `check-slack-bot-slash`, whose handler is `slash.handler`. It should use subnets `B`, `C` and `D`. **[8]**
+* Add a trigger to this Lambda function, of type "API Gateway". The API should have a single endpoint, that accepts only `POST` requests. **[9]**
+  * `Integration Request`: By default, the AWS API Gateway only accepts `application/json` requests, but Slack is going to send `application/x-www-form-urlencoded` requests when a message button is clicked. So, add a `Mapping Template` to your API `POST` method for the content type `application/x-www-form-urlencoded`. The contents of the template should be `{ "body": "$input.body" }`. Also, under the "Binary Support" section, add `application/x-www-form-urlencoded` as a content type to be considered binary input.
+  * `Integration Response`: The template configuration for `200` status will cause the slash command to display to the user `null` as response when the function returns no message (`help` command, for example). To avoid this, need to define a mapping template that returns the message when there is a message and will return nothing if the message is blank. So, add a `Mapping Template` for the content type `application/json`. The content of the template should be `#if($input.path('$') != '')$input.path('$')#end`.
+  * Remember to deploy your API once all those things are done.
+* Create a Lambda function called `slash-response`, whose handler is `slash-response.handler`. It should use subnets `B`, `C` and `D`. **[10]**
+* Now on the Slack app side **[11]**, you need to do a few things:
   * On "Basic Information", copy the verification token to `config.js`, as `slack.verificationToken`
   * On "Interactive Components", put in the "Request URL" field the HTTP path to your `check-slack-bot-buttons` function
   * On "OAuth & Permissions", copy the "OAuth Access Token" to `config.js` as `slack.accessToken`, and add the following scopes: `channels.history`, `chat:write:bot` and `chat:write:user`
   * On "Event Subscriptions", enable events, put in the "Request URL" field the HTTP path to your `check-slack-bot` function and subscribe to the workspace event `message.channels`
   * On "Bot Users", add a new bot called Check
-* Finally, at the Check side **[9]**, create a new global API key and add to `config.js` as `checkApi.apiKey`.
+  * On "Basic Information" => "Add features and functionality", click on "Slash Commands" and create a new command. On `Command` add the name that will be called (`check` or `bridge`). Put in "Request URL" field the HTTP path to your `check-slack-bot-slash` function. The function needs to recognize URL, so check the option "Escape channels, users, and links sent to your app". Save the changes
+* Finally, at the Check side **[12]**, create a new global API key and add to `config.js` as `checkApi.apiKey`.
 
 Now that everything should be running smoothly, let's use it.
 
@@ -51,6 +58,14 @@ The steps below reference the **yellow** circles on the diagram above.
   * If it's a "change status" action, the bot asks Check API for the token of a Check user related to that Slack user **[7]**. If there is such user, the bot uses that token to send a mutation to Check API **[7]** to change the status of that media. After the mutation completes, the existing Slack message is updated with the new status **[5]**.
   * If it's a "image search" action, the bot asks Check API for the token of a Check user related to that Slack user **[7]**. If there is such user, the bot replies immediately to Slack **[5]** (because Slack only waits until 3s for an interactive button response) and, at same time, makes an asynchronous request to the `google-image-search` function, using AWS SDK **[8]**. That function will look for similar images on Google an send a message to Slack with the results **[9]**.
 * **[10]** When a comment is created from Check UI or when a translation is created from Bridge UI or when a report status, title or description is changed from Check UI, Check sends a request to Slack in order to add a new message to a thread or to update an existing Slack message, respectively. This is done _only_ if the report on Check has at least one `slack_message` annotation, which connects a Check report to a Slack message id.
+
+
+* **[11]** The Slash command let users trigger an interaction with your app directly from the message box in Slack. So, when a user posts the command defined (`check` or `bridge`), Slack makes a request to the `check-slack-bot-slash` lambda function and replies immediately to confirm the receipt.
+The function verify the text sent and calls the function `slash-response` if the team token is valid and the Slack user is registered on Check.
+* **[12]** If the message contains `set [project url]` the lambda function makes a GraphQL request to Check API using the global token, asking for information about the project. If the project is valid, the function will save on Redis the channel and the project and reply on Slack a success message **[13]**
+* If the message contains `show` the lambda function verify on Redis **[14]** if that channel is related to any Check project. If so, reply on Slack the project url that is defined for the channel **[13]**
+* If the message contains `[URL]`, the lambda function verify on Redis **[14]** if that channel is related to any Check project. If so, the funcion uses the user token to send a mutation to Check API and create a project media **[15]**. After the mutation completes, reply on Slack a message with the project media url **[13]**
+* If the message contains an empty string or a text that is not recognized, the lambda function reply on Slack a message with the list of available commands **[13]**
 
 ## Tests
 

--- a/config.js.example
+++ b/config.js.example
@@ -18,6 +18,7 @@ const config = {
   redisHost: 'without protocol or port, only the hostname',
   redisPrefix: 'check',
   awsRegion: 'us-east-1',
-  googleImageSearchFunctionName: 'if not provided, defaults to "google-image-search"'
+  googleImageSearchFunctionName: 'if not provided, defaults to "google-image-search"',
+  bot_id: 'BOTID'
 };
 module.exports = config;

--- a/config.js.example
+++ b/config.js.example
@@ -20,6 +20,6 @@ const config = {
   awsRegion: 'us-east-1',
   googleImageSearchFunctionName: 'if not provided, defaults to "google-image-search"',
   slashResponseFunctionName: 'if not provided, defaults to "slash-response"',
-  bot_id: 'BOTID'
+  botId: 'BOTID'
 };
 module.exports = config;

--- a/config.js.example
+++ b/config.js.example
@@ -19,6 +19,7 @@ const config = {
   redisPrefix: 'check',
   awsRegion: 'us-east-1',
   googleImageSearchFunctionName: 'if not provided, defaults to "google-image-search"',
+  slashResponseFunctionName: 'if not provided, defaults to "slash-response"',
   bot_id: 'BOTID'
 };
 module.exports = config;

--- a/config.js.test
+++ b/config.js.test
@@ -21,6 +21,7 @@ const config = {
   redisHost: 'localhost',
   redisPrefix: 'qa',
   awsRegion: 'us-east-1',
-  googleImageSearchFunctionName: 'google-image-search-test'
+  googleImageSearchFunctionName: 'google-image-search-test',
+  bot_id: 'BOTID'
 };
 module.exports = config;

--- a/config.js.test
+++ b/config.js.test
@@ -23,6 +23,6 @@ const config = {
   awsRegion: 'us-east-1',
   googleImageSearchFunctionName: 'google-image-search-test',
   slashResponseFunctionName: 'slash-response-test',
-  bot_id: 'BOTID'
+  botId: 'BOTID'
 };
 module.exports = config;

--- a/config.js.test
+++ b/config.js.test
@@ -22,7 +22,7 @@ const config = {
   redisPrefix: 'qa',
   awsRegion: 'us-east-1',
   googleImageSearchFunctionName: 'google-image-search-test',
-  slashResponseFunctionName: 'slash-response',
+  slashResponseFunctionName: 'slash-response-test',
   bot_id: 'BOTID'
 };
 module.exports = config;

--- a/config.js.test
+++ b/config.js.test
@@ -22,6 +22,7 @@ const config = {
   redisPrefix: 'qa',
   awsRegion: 'us-east-1',
   googleImageSearchFunctionName: 'google-image-search-test',
+  slashResponseFunctionName: 'slash-response',
   bot_id: 'BOTID'
 };
 module.exports = config;

--- a/config.test.js
+++ b/config.test.js
@@ -15,7 +15,8 @@ test('well formed', () => {
       redisHost: expect.any(String),
       redisPrefix: expect.any(String),
       awsRegion: expect.any(String),
-      googleImageSearchFunctionName: expect.any(String)
+      googleImageSearchFunctionName: expect.any(String),
+      slashResponseFunctionName: expect.any(String)
     })
   );
 });

--- a/index.js
+++ b/index.js
@@ -66,14 +66,14 @@ const getProjectMedia = function(teamSlug, projectId, projectMediaId, callback, 
   });
 };
 
-const displayCard = function(checkURLPattern, bot_id, text) {
+const displayCard = function(checkURLPattern, botId, text) {
   if (!text) { return false }
   const slashBotCreatedPMRegexp = new RegExp(projectMediaCreatedMessage());
   const urlFromBotRegexp = new RegExp('\<' + checkURLPattern + '(?!\|)\>');
-  switch(bot_id) {
+  switch(botId) {
     case undefined:
       return true;
-    case config.bot_id:
+    case config.botId:
       return slashBotCreatedPMRegexp.test(text)
     default:
       return urlFromBotRegexp.test(text)

--- a/slash-response.js
+++ b/slash-response.js
@@ -158,22 +158,22 @@ const showProject = function(payload, callback) {
 const showTips = function(payload, callback) {
   let message = {
     response_type: 'ephemeral',
-    text: ':wave: ' + t('need_some_help_with') + ' ` /' + config.appName + '`?',
+    text: ':wave: ' + t('need_some_help_with') + ' `' + payload.body.command + '`?',
     attachments: [
       {
-        text: t('define_the_default_project_for_this_channel') + ':\n `/' + config.appName + ' set ' + config.checkWeb.url + '/[team slug]/project/[project id]`',
+        text: t('define_the_default_project_for_this_channel') + ':\n `' + payload.body.command + ' set ' + config.checkWeb.url + '/[team slug]/project/[project id]`',
         mrkdwn_in: ['text'],
-        fallback: t('define_the_default_project_for_this_channel') + ':\n `/' + config.appName + ' set ' + config.checkWeb.url + '/[team slug]/project/[project id]`'
+        fallback: t('define_the_default_project_for_this_channel') + ':\n `' + payload.body.command + ' set ' + config.checkWeb.url + '/[team slug]/project/[project id]`'
       },
       {
-        text: t('show_the_default_project_for_this_channel') + ':\n `/' + config.appName + ' show`',
+        text: t('show_the_default_project_for_this_channel') + ':\n `' + payload.body.command + ' show`',
         mrkdwn_in: ['text'],
-        fallback: t('show_the_default_project_for_this_channel') + ':\n `/' + config.appName + ' show`'
+        fallback: t('show_the_default_project_for_this_channel') + ':\n `' + payload.body.command + ' show`'
       },
       {
-        text: t('send_a_URL_to') + ' ' + humanAppName() + '. ' + t('a_default_project_for_this_channel_must_be_already_defined') + ':\n `/' + config.appName + ' [URL]`',
+        text: t('send_a_URL_to') + ' ' + humanAppName() + '. ' + t('a_default_project_for_this_channel_must_be_already_defined') + ':\n `' + payload.body.command + ' [URL]`',
         mrkdwn_in: ['text'],
-        fallback: t('send_the_URL_to') + ' ' + humanAppName() + '. ' + t('a_default_project_for_this_channel_must_be_already_defined') + ':\n `/' + config.appName + ' [URL]`'
+        fallback: t('send_the_URL_to') + ' ' + humanAppName() + '. ' + t('a_default_project_for_this_channel_must_be_already_defined') + ':\n `' + payload.body.command + ' [URL]`'
       }]
   };
   replyToSlack(payload.body.team_id, payload.body.response_url, message, callback);

--- a/slash-response.js
+++ b/slash-response.js
@@ -1,0 +1,197 @@
+// This function adds a ProjectMedia to Check or Bridge and sends a message back to Slack
+
+const config = require('./config.js'),
+      request = require('request'),
+      util = require('util'),
+      qs = require('querystring'),
+      https = require('https');
+
+const { executeMutation, getRedisClient, t, getGraphqlClient, getTeamConfig, saveToRedisAndReplyToSlack, projectMediaCreatedMessage, humanAppName } = require('./helpers.js');
+
+const replyToSlack = function(team, responseUrl, message, callback) {
+  request.post({ url: responseUrl, json: true, body: message, headers: { 'Content-type': 'application/json' } }, function(err, res, resjson) {
+    console.log('Response from Slack message update: ' + util.inspect(res));
+  });
+  callback(null, message);
+};
+
+const getProject = function(teamSlug, projectId, token, done, fail, callback) {
+  const client = getGraphqlClient(teamSlug, token, callback);
+  const projectQuery = `
+  query project($ids: String!) {
+    project(ids: $ids) {
+      dbid
+      title
+      description
+      team {
+        name
+        slug
+      }
+    }
+  }
+  `;
+  client.query(projectQuery, { ids: projectId.toString() })
+  .then((resp, errors) => {
+    console.log('GraphQL query response: ' + util.inspect(resp));
+    done(resp);
+  })
+  .catch(function(e) {
+    fail(e);
+    console.log('GraphQL query exception: ' + e.toString());
+  });
+};
+
+const sendErrorMessage = function(e, vars, text, team_id, responseUrl, callback) {
+  const message = { response_type: "ephemeral", text: text };
+  if (e.rawError && (error = e.rawError[0])) {
+    let error_message = error.message;
+    if (error.data && error.data.code === 'ERR_OBJECT_EXISTS') { error_message += ': ' + error.data.url; };
+
+    message.attachments = [{
+      color: 'warning',
+      text: error_message,
+      footer: vars.url,
+      fallback: error_message
+    }]
+  };
+  console.log('Error: ' + util.inspect(e));
+  replyToSlack(team_id, responseUrl, message, callback);
+};
+
+const createProjectMedia = function(team_id, responseUrl, vars, token, data, callback) {
+  const mutationQuery = `($pid: Int!, $url: String!, $clientMutationId: String!) {
+    createProjectMedia: createProjectMedia(input: { clientMutationId: $clientMutationId, url: $url, project_id: $pid }) {
+      project_media {
+        dbid
+        metadata
+        url
+        quote
+      }
+    }
+  }`;
+
+  const fail = function(callback, thread, channel, link, e) {
+    const text = t("sorry,_can't_add_the_URL") + ' ' + link;
+    sendErrorMessage(e, vars, text, team_id, responseUrl, callback);
+  };
+
+  const done = function(resp) {
+    console.log('GraphQL query response: ' + util.inspect(resp));
+    const metadata = JSON.parse(resp.createProjectMedia.project_media.metadata);
+    let message = { response_type: "in_channel", text: projectMediaCreatedMessage() + metadata.permalink };
+    replyToSlack(team_id, responseUrl, message, callback);
+    callback(null, message);
+  };
+
+  executeMutation(mutationQuery, vars, fail, done, token, callback, {}, data);
+};
+
+const addUrl = function(payload, callback) {
+  const responseUrl = payload.body.response_url;
+  const team_id = payload.body.team_id;
+  const url = payload.matches[1];
+  const vars =  { url: url, clientMutationId: `fromSlackMessage:${payload.body.trigger_id}`};
+  const redis = getRedisClient();
+  redis.get(REDIS_KEY, function(err, reply) {
+    if (!reply) {
+      console.log('Could not find Redis key for channel' + ' #' + payload.body.channel_name);
+      let message = { text: t('default_project_not_defined_for_this_channel'), response_type: 'ephemeral' };
+      replyToSlack(team_id, responseUrl, message, callback);
+    }
+    else {
+      const data = JSON.parse(reply.toString());
+      data.link = url;
+      vars.pid = parseInt(data.project_id);
+      createProjectMedia(team_id, responseUrl, vars, payload.user_token, data, callback);
+    }
+    redis.quit();
+  });
+  console.log('Add URL to ' + humanAppName() + ': ' + url);
+};
+
+const setProject = function(payload, callback) {
+  const projectUrl = payload.matches[0],
+        teamSlug = payload.matches[1],
+        projectId = payload.matches[2];
+
+  const fail = function(e) {
+    const text = t("sorry,_can't_find_project") + ' ' + projectUrl;
+    const vars = { url: projectUrl };
+    sendErrorMessage(e, vars, text, payload.body.team_id, payload.body.response_url, callback);
+  };
+
+  const done = function(data) {
+    const value = { team_slug: teamSlug, project_id: data.project.dbid, project_title: data.project.title, project_url: payload.matches[0]};
+    const message = { text: t('project_set') + ': ' + value['project_url'], response_type: 'ephemeral' };
+
+    const success = function() {
+      replyToSlack(payload.body.team_id, payload.body.response_url, message, callback);
+    };
+
+    saveToRedisAndReplyToSlack(REDIS_KEY, value, message, success, callback);
+  };
+
+  //Handle if project doesn't exist
+  getProject(teamSlug, projectId, payload.user_token, done, fail, callback);
+  console.log('Set project: ' + projectUrl);
+};
+
+const showProject = function(payload, callback) {
+  let message = ''
+  const redis = getRedisClient();
+  redis.on('connect', function() {
+    redis.get(REDIS_KEY, function(err, reply) {
+      if (!reply) {
+        console.log('Could not find Redis key for channel' + ' #' + payload.body.channel_name);
+        message = { text: t('default_project_not_defined_for_this_channel'), response_type: 'ephemeral' };
+      }
+      else {
+        const data = JSON.parse(reply.toString());
+        message = { text: t('project_set_to_channel') + ': ' + data.project_url, response_type: 'ephemeral' };
+      }
+      replyToSlack(payload.body.team_id, payload.body.response_url, message, callback);
+    });
+    redis.quit();
+  });
+};
+
+const showTips = function(payload, callback) {
+  let message = {
+    response_type: 'ephemeral',
+    text: ':wave: ' + t('need_some_help_with') + ' ` /' + config.appName + '`?',
+    attachments: [
+      {
+        text: t('define_the_default_project_for_this_channel') + ':\n `/' + config.appName + ' set ' + config.checkWeb.url + '/[team slug]/project/[project id]`',
+        mrkdwn_in: ['text'],
+        fallback: t('define_the_default_project_for_this_channel') + ':\n `/' + config.appName + ' set ' + config.checkWeb.url + '/[team slug]/project/[project id]`'
+      },
+      {
+        text: t('show_the_default_project_for_this_channel') + ':\n `/' + config.appName + ' show`',
+        mrkdwn_in: ['text'],
+        fallback: t('show_the_default_project_for_this_channel') + ':\n `/' + config.appName + ' show`'
+      },
+      {
+        text: t('send_a_URL_to') + ' ' + humanAppName() + '. ' + t('a_default_project_for_this_channel_must_be_already_defined') + ':\n `/' + config.appName + ' [URL]`',
+        mrkdwn_in: ['text'],
+        fallback: t('send_the_URL_to') + ' ' + humanAppName() + '. ' + t('a_default_project_for_this_channel_must_be_already_defined') + ':\n `/' + config.appName + ' [URL]`'
+      }]
+  };
+  replyToSlack(payload.body.team_id, payload.body.response_url, message, callback);
+};
+
+exports.handler = function(event, context, callback) {
+  REDIS_KEY = 'slack_channel_project:' + config.redisPrefix + ':' + event.body.channel_id;
+  switch (event.type) {
+    case 'createProjectMedia':
+      addUrl(event, callback);
+      break;
+    case 'setProject':
+      setProject(event, callback);
+      break;
+    case 'showProject':
+      showProject(event, callback);
+      break;
+    default:
+      showTips(event, callback);
+  }
+};

--- a/slash-response.test.js
+++ b/slash-response.test.js
@@ -52,13 +52,13 @@ test('verify if type is valid on call', async () => {
   storeLog = inputs => (outputData += inputs);
   console['log'] = jest.fn(storeLog);
 
-  const data = { type: "invalidType", body: { text: 'invalid input', team_id: 'T12345ABC', responseUrl: 'https://hooks.slack.com/'}};
+  const data = { type: "invalidType", body: { text: 'invalid input', team_id: 'T12345ABC', responseUrl: 'https://hooks.slack.com/', command: '/check'}};
   const callback = jest.fn();
 
   sr.handler(data, null, callback);
   await sleep(3);
   expect(outputData).toMatch('Response from Slack');
-  expect(callback).toHaveBeenCalledWith(null, expect.objectContaining({ text: expect.stringContaining('Need some help') }));
+  expect(callback).toHaveBeenCalledWith(null, expect.objectContaining({ text: expect.stringContaining('Need some help with `/check`?') }));
 });
 
 test('call add url if type is createProjectMedia', () => {

--- a/slash-response.test.js
+++ b/slash-response.test.js
@@ -1,0 +1,220 @@
+const { exec } = require('child_process');
+const btoa = require('btoa');
+const fetch = require('node-fetch');
+let config = require('./config');
+const sr = require('./slash-response');
+
+const {
+  sleep,
+  buildRandomString,
+  callCheckApi,
+} = require('./test-helpers');
+
+jest.setTimeout(120000);
+
+const createUser = async () => {
+  await callCheckApi('new_api_key', { access_token: config.checkApi.apiKey });
+  await sleep(1);
+
+  const uuid = buildRandomString();
+  const token = buildRandomString();
+  const email = buildRandomString() + '@test.com';
+  const user = await callCheckApi('user', { provider: 'slack', uuid, token, is_admin: true });
+  console.log(user);
+  return user;
+};
+
+const projectData = async () => {
+  const user = await createUser();
+  email = user.data.email;
+  const team = await callCheckApi('team', { email });
+  const project = await callCheckApi('project', { team_id: team.data.dbid });
+  await callCheckApi('get', { class: 'project', id: project.data.dbid, fields: 'id,graphql_id' });
+  const projectUrl = config.checkWeb.url + '/' + team.data.slug + '/project/' + project.data.dbid;
+
+  const data = {
+    project: project,
+    team: team,
+    projectUrl: projectUrl,
+    user: user
+  };
+  return data;
+};
+
+const sendToRedis = async (response, channelId) => {
+  const key = 'slack_channel_project:' + config.redisPrefix + ':' + channelId;
+  const value = JSON.stringify({ team_slug: response.team.data.slug, project_id: response.project.data.dbid, project_title: response.project.data.title, project_url: response.projectUrl });
+  await exec(`redis-cli set ${key} '${value}'`);
+};
+
+test('verify if type is valid on call', async () => {
+  let outputData = '';
+  storeLog = inputs => (outputData += inputs);
+  console['log'] = jest.fn(storeLog);
+
+  const data = { type: "invalidType", body: { text: 'invalid input', team_id: 'T12345ABC', responseUrl: 'https://hooks.slack.com/'}};
+  const callback = jest.fn();
+
+  sr.handler(data, null, callback);
+  await sleep(3);
+  expect(outputData).toMatch('Response from Slack');
+  expect(callback).toHaveBeenCalledWith(null, expect.objectContaining({ text: expect.stringContaining('Need some help') }));
+});
+
+test('call add url if type is createProjectMedia', () => {
+  const url = 'https://ca.ios.ba/'
+  const data = { type: "createProjectMedia", body: { team_id: 'T12345ABC', responseUrl: 'https://hooks.slack.com/'}, matches: ['', url, '1']};
+  const callback = jest.fn();
+  let outputData = '';
+  storeLog = inputs => (outputData += inputs);
+  console['log'] = jest.fn(storeLog);
+
+  sr.handler(data, null, callback);
+  expect(outputData).toMatch('Add URL to Check: ' + url);
+});
+
+test('call set project if type is setProject', () => {
+  const projectUrl = config.checkWeb.url + '/my-team/project/1';
+  const data = { type: "setProject", body: { team_id: 'T02528QUL', responseUrl: 'https://hooks.slack.com/'}, matches: [projectUrl, 'my-team', '1']};
+  const callback = jest.fn();
+  let outputData = '';
+  storeLog = inputs => (outputData += inputs);
+  console['log'] = jest.fn(storeLog);
+
+  sr.handler(data, null, callback);
+  expect(outputData).toMatch('Set project: ' + projectUrl);
+});
+
+test('return error message if cannot find project and type is setProject', async () => {
+  const projectUrl = config.checkWeb.url + '/my-team/project/1';
+  const user = await createUser();
+  const data = { type: "setProject", body: { team_id: 'T12345ABC', responseUrl: 'https://hooks.slack.com/'}, matches: [projectUrl, 'my-team', '1'], user_token: user.data.token};
+  const callback = jest.fn();
+
+  let outputData = '';
+  storeLog = inputs => (outputData += inputs);
+  console['log'] = jest.fn(storeLog);
+
+  sr.handler(data, null, callback);
+  await sleep(3);
+  expect(outputData).toMatch('GraphQL query exception: Error: Invalid status code: 404');
+  expect(callback).toHaveBeenCalledWith(null, expect.objectContaining({ text: expect.stringContaining("can't find project") }));
+});
+
+test('return save to redis and reply to slack when input is valid and type is setProject', async () => {
+  let outputData = '';
+  storeLog = inputs => (outputData += inputs);
+  console['log'] = jest.fn(storeLog);
+
+  const response = await projectData();
+  const data = { type: "setProject", body: { team_id: 'T02528QUL', responseUrl: 'https://hooks.slack.com/', channel_id: 'the-channel'}, matches: [response.projectUrl, response.team.data.slug, response.project.data.dbid], user_token: response.user.data.token};
+  const callback = jest.fn();
+
+	sr.handler(data, null, callback);
+  await sleep(2);
+
+  expect(outputData).toMatch('GraphQL query response');
+  expect(outputData).toMatch('Saved on Redis key');
+  expect(callback).toHaveBeenCalledWith(null, expect.objectContaining({ text: expect.stringContaining('Project set') }));
+});
+
+test('return error message when try to add a url and channel project is not defined', async () => {
+  let outputData = '';
+  storeLog = inputs => (outputData += inputs);
+  console['log'] = jest.fn(storeLog);
+
+  const response = await projectData();
+  const url = 'https://ca.ios.ba/'
+  const data = { type: "createProjectMedia", body: { team_id: 'T12345ABC', responseUrl: 'https://hooks.slack.com/'}, matches: ['', url, response.project.data.dbid], user_token: response.user.data.token};
+
+  const callback = jest.fn();
+
+  sr.handler(data, null, callback);
+  await sleep(2);
+
+  expect(outputData).toMatch('Could not find Redis key');
+  expect(callback).toHaveBeenCalledWith(null, expect.objectContaining({ text: expect.stringContaining('Default project not defined') }));
+});
+
+test('successfully add url', async () => {
+  let outputData = '';
+  storeLog = inputs => (outputData += inputs);
+  console['log'] = jest.fn(storeLog);
+
+  const response = await projectData();
+  await sendToRedis(response, 'the-channel');
+
+  const url = 'https://ca.ios.ba/'
+  const data = { type: "createProjectMedia", body: { team_id: 'T02528QUL', responseUrl: 'https://hooks.slack.com/', channel_id: 'the-channel'}, matches: ['', url, response.project.data.dbid], user_token: response.user.data.token};
+  const callback = jest.fn();
+
+  sr.handler(data, null, callback);
+  await sleep(8);
+
+  expect(outputData).toMatch('Add URL to Check: ' + url);
+  expect(callback).toHaveBeenCalledWith(null, expect.objectContaining({ text: expect.stringContaining('URL successfully added to Check') }));
+});
+
+test('return error message if duplicated url and its url', async () => {
+  const response = await projectData();
+  await sendToRedis(response, 'the-channel');
+
+  const url = 'https://ca.ios.ba/'
+
+  let pm = await callCheckApi('link', { url: url, team_id: response.team.data.dbid, project_id: response.project.data.dbid });
+  pm = await callCheckApi('get', { class: 'project_media', id: pm.data.id, fields: 'metadata' });
+
+  const data = { type: "createProjectMedia", body: { team_id: 'T02528QUL', responseUrl: 'https://hooks.slack.com/', channel_id: 'the-channel'}, matches: ['', url, response.project.data.dbid], user_token: response.user.data.token};
+  const callback = jest.fn();
+
+  sr.handler(data, null, callback);
+  await sleep(8);
+
+  expect(callback).toHaveBeenCalledWith(null, expect.objectContaining({ text: expect.stringContaining("Sorry, can't add the URL") }));
+  expect(callback).toHaveBeenCalledWith(null, expect.objectContaining({ attachments: expect.arrayContaining([expect.objectContaining({text: 'This media already exists: ' + JSON.parse(pm.data.metadata).permalink})])}));
+});
+
+test('return error message if project is archived', async () => {
+  const response = await projectData();
+  await sendToRedis(response, 'the-channel');
+
+  const url = 'https://ca.ios.ba/'
+
+  const pm = await callCheckApi('link', { url: url, team_id: response.team.data.dbid, project_id: response.project.data.dbid });
+  await callCheckApi('archive_project', { project_id: pm.data.project_id });
+
+  const data = { type: "createProjectMedia", body: { team_id: 'T02528QUL', responseUrl: 'https://hooks.slack.com/', channel_id: 'the-channel'}, matches: ['', 'https://meedan.com/en', response.project.data.dbid], user_token: response.user.data.token};
+  const callback = jest.fn();
+
+	sr.handler(data, null, callback);
+  await sleep(8);
+
+  expect(callback).toHaveBeenCalledWith(null, expect.objectContaining({ text: expect.stringContaining("Sorry, can't add the URL") }));
+  expect(callback).toHaveBeenCalledWith(null, expect.objectContaining({ attachments: expect.arrayContaining([expect.objectContaining({text: expect.stringContaining('Validation failed')})])}));
+});
+
+test('return error message when try to show project but not defined on channel', async () => {
+  const user = await createUser();
+  const data = { type: "showProject", body: { team_id: 'T12345ABC', responseUrl: 'https://hooks.slack.com/'}, user_token: user.data.token};
+
+  const callback = jest.fn();
+
+  sr.handler(data, null, callback);
+  await sleep(2);
+
+  expect(callback).toHaveBeenCalledWith(null, expect.objectContaining({ text: expect.stringContaining('Default project not defined') }));
+});
+
+test('show project set to channel', async () => {
+  const response = await projectData();
+  await sendToRedis(response, 'the-channel');
+
+  const data = { type: "showProject", body: { team_id: 'T12345ABC', responseUrl: 'https://hooks.slack.com/', channel_id: 'the-channel'}, user_token: response.user.data.token};
+
+  const callback = jest.fn();
+
+  sr.handler(data, null, callback);
+  await sleep(2);
+
+  expect(callback).toHaveBeenCalledWith(null, expect.objectContaining({ text: expect.stringContaining('Project set to channel: ' + response.projectUrl) }));
+});

--- a/slash.js
+++ b/slash.js
@@ -1,0 +1,75 @@
+// This function adds a ProjectMedia to Check and sends a message back to Slack
+
+/*
+ * data = {
+ *   project_id,
+ *   url,
+ *   response_url,
+ * }
+ */
+
+const config = require('./config.js'),
+      request = require('request'),
+      util = require('util'),
+      qs = require('querystring'),
+      aws = require('aws-sdk');
+
+const { getCheckSlackUser, t, getTeamConfig, humanAppName } = require('./helpers.js');
+
+const permissionError = function(callback) {
+  callback(null, t('Sorry,_seems_that_you_do_not_have_the_permission_to_do_this._Please_go_to_the_app_and_login_by_your_Slack_user,_or_continue_directly_from_there') + ': ' + config.checkWeb.url );
+};
+
+const process = function(body, token, callback) {
+  const setProjectRegexp = new RegExp(/set <(.+)>/, 'g');
+  const showProjectRegexp = new RegExp(/show/, 'g');
+  const addUrlRegexp = new RegExp(/<(.+)>/, 'g');
+
+  let action = '';
+  if (projectUrl = setProjectRegexp.exec(body.text)) {
+    const projectRegexp = new RegExp(config.checkWeb.url + '/([^/]+)/project/([0-9]+)', 'g');
+      if (matches = projectRegexp.exec(projectUrl[1])) {
+        text = t('setting_project...');
+        action = 'setProject';
+      } else { text = t('invalid_project_URL') + ': ' + projectUrl[1]; }
+  } else if (matches = showProjectRegexp.exec(body.text)) {
+    text = t('getting_project...');
+    action = 'showProject';
+  } else if (matches = addUrlRegexp.exec(body.text)) {
+    text = t('sending_URL_to') + ' ' + humanAppName() + ': ' + matches[1];
+    action = 'createProjectMedia';
+  } else {
+    text = '';
+    action = 'showTips';
+  };
+
+  if (action != '') {
+    const payload = { type: action, body: body, matches: matches, user_token: token }
+    try {
+      const lambda = new aws.Lambda({ region: config.awsRegion });
+      lambdaRequest = lambda.invoke({ FunctionName: 'slash-response', InvocationType: 'Event', Payload: JSON.stringify(payload) });
+      const lambdaReturn = lambdaRequest.send();
+    } catch (e) {}
+  };
+  console.log(text);
+  callback(null, text);
+};
+
+exports.handler = function(event, context, callback) {
+  const body = qs.parse(decodeURIComponent(event.body));
+  const teamConfig = getTeamConfig(body.team_id);
+  if (body.token === teamConfig.verificationToken) {
+    getCheckSlackUser(body.user_id,
+      function(err) {
+        console.log('Error when trying to identify Slack user: ' + util.inspect(err));
+        permissionError(callback);
+      },
+      function(token) {
+        console.log('Successfully identified as Slack user with token: ' + token);
+        process(body, token, callback);
+    });
+  } else {
+    console.log('Invalid request token: ' + body.token);
+    permissionError(callback);
+  }
+};

--- a/slash.js
+++ b/slash.js
@@ -22,7 +22,7 @@ const permissionError = function(callback) {
 
 const process = function(body, token, callback) {
   const setProjectRegexp = new RegExp(/set <(.+)>/, 'g');
-  const showProjectRegexp = new RegExp(/show/, 'g');
+  const showProjectRegexp = new RegExp(/^show/, 'g');
   const addUrlRegexp = new RegExp(/<(.+)>/, 'g');
 
   let action = '';
@@ -47,7 +47,8 @@ const process = function(body, token, callback) {
     const payload = { type: action, body: body, matches: matches, user_token: token }
     try {
       const lambda = new aws.Lambda({ region: config.awsRegion });
-      lambdaRequest = lambda.invoke({ FunctionName: 'slash-response', InvocationType: 'Event', Payload: JSON.stringify(payload) });
+      const functionName = config.slashResponseFunctionName || 'slash-response';
+      lambdaRequest = lambda.invoke({ FunctionName: functionName, InvocationType: 'Event', Payload: JSON.stringify(payload) });
       const lambdaReturn = lambdaRequest.send();
     } catch (e) {}
   };

--- a/slash.test.js
+++ b/slash.test.js
@@ -94,6 +94,21 @@ test('verify show on call', async () => {
   expect(callback).toHaveBeenCalledWith(null, expect.stringContaining('Getting project'));
 });
 
+test('ignore show that is not in the beggining of command', async () => {
+  const user = await apiData();
+  const data = { body: "team_id=T12345ABC&token=123456abcdef&user_id=" + user.data.uuid + "&text=<http://www.commitstrip.com/en/2014/08/19/when-a-colleague-put-his-fingers-on-my-screen-to-show-me-something>"};
+  const callback = jest.fn();
+  const context = jest.fn();
+
+  let outputData = '';
+  storeLog = inputs => (outputData += inputs);
+  console['log'] = jest.fn(storeLog);
+
+  slash.handler(data, context, callback);
+  await sleep(3);
+  expect(callback).toHaveBeenCalledWith(null, expect.stringContaining('Sending URL to'));
+});
+
 test('accept empty command on call', async () => {
   const user = await apiData();
   const data = { body: "team_id=T12345ABC&token=123456abcdef&user_id=" + user.data.uuid + "&text="};

--- a/slash.test.js
+++ b/slash.test.js
@@ -1,0 +1,150 @@
+const btoa = require('btoa');
+const fetch = require('node-fetch');
+let aws = require('aws-sdk');
+const awsMock = require('aws-sdk-mock');
+let config = require('./config');
+const slash = require('./slash');
+
+const { sleep, callCheckApi, buildRandomString } = require('./test-helpers');
+
+jest.setTimeout(120000);
+
+const apiData = async () => {
+  await callCheckApi('new_api_key', { access_token: config.checkApi.apiKey });
+  await sleep(1);
+
+  const uuid = buildRandomString();
+  const token = buildRandomString();
+  const email = buildRandomString() + '@test.com';
+  const user = await callCheckApi('user', { provider: 'slack', uuid, token, is_admin: true });
+
+  return user;
+};
+
+test('verify input format on call', async () => {
+  const user = await apiData();
+  const data = { body: "team_id=T12345ABC&token=123456abcdef&user_id=" + user.data.uuid + "&text=unknown"};
+  const callback = jest.fn();
+
+  let outputData = '';
+  storeLog = inputs => (outputData += inputs);
+  console['log'] = jest.fn(storeLog);
+
+  slash.handler(data, null, callback);
+  await sleep(3);
+  expect(callback).toHaveBeenCalledWith(null, '');
+});
+
+test('verify url and project on call', async () => {
+  const user = await apiData();
+  const data = { body: "team_id=T12345ABC&token=123456abcdef&user_id=" + user.data.uuid + "&text=<https://ca.ios.ba/>"};
+  const callback = jest.fn();
+
+  let outputData = '';
+  storeLog = inputs => (outputData += inputs);
+  console['log'] = jest.fn(storeLog);
+
+  slash.handler(data, null, callback);
+  await sleep(3);
+  expect(callback).toHaveBeenCalledWith(null, expect.stringContaining('Sending URL to Check'));
+});
+
+test('verify set and valid check link on call', async () => {
+  const projectUrl = config.checkWeb.url + '/my-team/project/1';
+  const user = await apiData();
+  const data = { body: "team_id=T12345ABC&token=123456abcdef&user_id=" + user.data.uuid + "&text=set <" + projectUrl + ">"};
+  const callback = jest.fn();
+
+  let outputData = '';
+  storeLog = inputs => (outputData += inputs);
+  console['log'] = jest.fn(storeLog);
+
+  slash.handler(data, null, callback);
+  await sleep(3);
+  expect(callback).toHaveBeenCalledWith(null, expect.stringContaining('Setting project...'));
+});
+
+test('verify set and invalid check link on call', async () => {
+  const projectUrl = 'http://invalid-domain/my-team/project/1';
+  const user = await apiData();
+  const data = { body: "team_id=T12345ABC&token=123456abcdef&user_id=" + user.data.uuid + "&text=set <" + projectUrl + ">"};
+  const callback = jest.fn();
+
+  let outputData = '';
+  storeLog = inputs => (outputData += inputs);
+  console['log'] = jest.fn(storeLog);
+
+  slash.handler(data, null, callback);
+  await sleep(3);
+  expect(callback).toHaveBeenCalledWith(null, expect.stringContaining('Invalid project URL: ' + projectUrl));
+});
+
+test('verify show on call', async () => {
+  const user = await apiData();
+  const data = { body: "team_id=T12345ABC&token=123456abcdef&user_id=" + user.data.uuid + "&text=show"};
+  const callback = jest.fn();
+  const context = jest.fn();
+
+  let outputData = '';
+  storeLog = inputs => (outputData += inputs);
+  console['log'] = jest.fn(storeLog);
+
+  slash.handler(data, context, callback);
+  await sleep(3);
+  expect(callback).toHaveBeenCalledWith(null, expect.stringContaining('Getting project'));
+});
+
+test('accept empty command on call', async () => {
+  const user = await apiData();
+  const data = { body: "team_id=T12345ABC&token=123456abcdef&user_id=" + user.data.uuid + "&text="};
+  const callback = jest.fn();
+
+  let outputData = '';
+  storeLog = inputs => (outputData += inputs);
+  console['log'] = jest.fn(storeLog);
+
+  slash.handler(data, null, callback);
+  await sleep(3);
+  expect(callback).toHaveBeenCalledWith(null, '');
+});
+
+test('accept help command on call', async () => {
+  const user = await apiData();
+  const data = { body: "team_id=T12345ABC&token=123456abcdef&user_id=" + user.data.uuid + "&text=help"};
+  const callback = jest.fn();
+
+  let outputData = '';
+  storeLog = inputs => (outputData += inputs);
+  console['log'] = jest.fn(storeLog);
+
+  slash.handler(data, null, callback);
+  await sleep(3);
+
+  expect(callback).toHaveBeenCalledWith(null, '');
+});
+
+test('return error if verification token is not valid', async () => {
+  let outputData = '';
+  storeLog = inputs => (outputData += inputs);
+  console['log'] = jest.fn(storeLog);
+
+  const data = { body: "team_id=T12345ABC&token=invalid"};
+  const callback = jest.fn();
+  slash.handler(data, null, callback);
+  expect(outputData).toMatch('Invalid request token');
+  expect(callback).toHaveBeenCalledWith(null, expect.stringContaining('do not have the permission'));
+});
+
+test('return error if Slack user cannot be identified', async () => {
+  const data = { body: "team_id=T12345ABC&token=123456abcdef&user_id=invalid"};
+  const callback = jest.fn();
+
+  let outputData = '';
+  storeLog = inputs => (outputData += inputs);
+  console['log'] = jest.fn(storeLog);
+
+  slash.handler(data, null, callback);
+  await sleep(3);
+  expect(outputData).toMatch('Error when trying to identify Slack user');
+  expect(callback).toHaveBeenCalledWith(null, expect.stringContaining('do not have the permission'));
+});

--- a/slash.test.js
+++ b/slash.test.js
@@ -163,3 +163,23 @@ test('return error if Slack user cannot be identified', async () => {
   expect(outputData).toMatch('Error when trying to identify Slack user');
   expect(callback).toHaveBeenCalledWith(null, expect.stringContaining('do not have the permission'));
 });
+
+test('call slash-response by default when not present on config', async () => {
+  let outputData = '';
+  storeLog = inputs => (outputData += inputs);
+  console['log'] = jest.fn(storeLog);
+  const functionName = config.slashResponseFunctionName;
+  config.slashResponseFunctionName = false;
+
+  const user = await apiData();
+  const data = { body: "team_id=T12345ABC&token=123456abcdef&user_id=" + user.data.uuid + "&text=help"};
+
+  const callback = jest.fn();
+  awsMock.mock('Lambda', 'invoke', function({}) { console.log('AWS Mocked Method'); });
+  slash.handler(data, null, callback);
+  await sleep(3);
+
+  expect(outputData).toMatch('AWS Mocked Method');
+  expect(callback).toHaveBeenCalledWith(null, '');
+  config.slashResponseFunctionName = functionName;
+});


### PR DESCRIPTION
Added commands:
- `set [project url]`: to store the default project for channel
- `show`: to show the defined projecta
- `[URL]`: to send url to Check or Bridge
- `[.*]`: show the list of acceptable commands

Update README file
Allow Slack to display Check card when bot post it